### PR TITLE
Add stencil functionality

### DIFF
--- a/src/main/java/com/corwinjv/mobtotems/items/ModItems.java
+++ b/src/main/java/com/corwinjv/mobtotems/items/ModItems.java
@@ -115,6 +115,37 @@ public class ModItems
                 'G', Items.gunpowder,
                 'F', Items.feather);
 
-        // TODO: Add crafting recipes for TotemStencil variants
+        item = mItems.get(TOTEM_STENCIL);
+        GameRegistry.addRecipe(new ItemStack(item, 1, TotemStencil.CREEPER_STENCIL_META),
+                "SSS",
+                "IGI",
+                "SSS",
+                'S',Items.stick,
+                'I', Items.iron_ingot,
+                'G', Items.gunpowder);
+
+        GameRegistry.addRecipe(new ItemStack(item, 1, TotemStencil.RABBIT_STENCIL_META),
+                "SSS",
+                "IDI",
+                "SSS",
+                'S',Items.stick,
+                'I', Items.iron_ingot,
+                'D', Items.wheat_seeds);
+
+        GameRegistry.addRecipe(new ItemStack(item, 1, TotemStencil.SLIME_STENCIL_META),
+                "SSS",
+                "IMI",
+                "SSS",
+                'S',Items.stick,
+                'I', Items.iron_ingot,
+                'M', Items.slime_ball);
+
+        GameRegistry.addRecipe(new ItemStack(item, 1, TotemStencil.WOLF_STENCIL_META),
+                "SSS",
+                "IMI",
+                "SSS",
+                'S',Items.stick,
+                'I', Items.iron_ingot,
+                'M', Items.bone);
     }
 }

--- a/src/main/java/com/corwinjv/mobtotems/items/TotemStencil.java
+++ b/src/main/java/com/corwinjv/mobtotems/items/TotemStencil.java
@@ -1,5 +1,6 @@
 package com.corwinjv.mobtotems.items;
 
+import com.corwinjv.mobtotems.blocks.TotemTileEntity;
 import com.corwinjv.mobtotems.blocks.TotemWood;
 import com.corwinjv.mobtotems.utils.BlockUtils;
 import net.minecraft.block.Block;
@@ -7,6 +8,7 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
@@ -89,11 +91,12 @@ public class TotemStencil extends BaseItem
     public boolean onItemUse(ItemStack stack, EntityPlayer player, World world, BlockPos pos, EnumFacing side, float hitX, float hitY, float hitZ) {
         if (!world.isRemote)
         {
-            Block targetBlock = BlockUtils.getBlock(world, pos);
-            if (targetBlock != null
-                    && targetBlock instanceof TotemWood)
+            TileEntity targetEntity = world.getTileEntity(pos);
+            if (targetEntity != null
+                    && targetEntity instanceof TotemTileEntity)
             {
-                // TODO: Do something with TotemWood or TotemWoodTileEntity
+                ((TotemTileEntity)targetEntity).setTotemType(stack.getMetadata());
+                player.destroyCurrentEquippedItem();
             }
         }
         return super.onItemUse(stack, player, world, pos, side, hitX, hitY, hitZ);


### PR DESCRIPTION
When the user activates it on a TotemWoodTileEntity, it sets the TotemWood's totemType and the item destroys itself
Added particle effects to differentiate between stencilled TotemWoodTileEntities
Also fix for Issue #3 
