### PR TITLE
Enable daemon for Gradle to improve continuous build speeds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
+org.gradle.daemon=true


### PR DESCRIPTION
Notes
---
- Enabling the daemon will speed up build times after the first Gradle build.
    - Gradle won't have to load a whole JVM into memory every time. It should only be discouraged for CI or build machines since you want builds to be as independent as possible.
- Also this warning was bugging me :)
    - `To honour the JVM settings for this build a new JVM will be forked. Please consider using the daemon: https://docs.gradle.org/2.14/userguide/gradle_daemon.html.`
